### PR TITLE
add jupyter env configurable with env vaiables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM yunabe/lgo:latest
 
 WORKDIR /examples
-
 # To use JupyterLab, replace "notebook" with "lab".
-CMD ["jupyter", "notebook", "--ip=0.0.0.0"]
+ENV JUPYTERENV=notebook
+ENTRYPOINT jupyter $JUPYTERENV --ip=0.0.0.0


### PR DESCRIPTION
I want to change from jupyter notebook to jupyterlab just changing environment variables.

`docker run -p 8888:8888 --name jupytergo -e JUPYTERENV=notebook -v ~/jupytergo/code:/examples -it jtemporal/jupytergo`

or

`docker run -p 8888:8888 --name jupytergo -e JUPYTERENV=lab -v ~/jupytergo/code:/examples -it jtemporal/jupytergo`